### PR TITLE
Remove unused hook and disbale eslint for dependencies

### DIFF
--- a/src/components/Ingredients/Ingredients.js
+++ b/src/components/Ingredients/Ingredients.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useCallback} from 'react';
+import React, {useState, useCallback} from 'react';
 
 import IngredientForm from './IngredientForm';
 import IngredientList from './IngredientList';

--- a/src/components/Ingredients/Search.js
+++ b/src/components/Ingredients/Search.js
@@ -38,6 +38,7 @@ const Search = React.memo(props => {
       clearTimeout(timer)
     }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enteredSearch, onFilterItemsBySearch, inputRef])
 
   return (


### PR DESCRIPTION
useEffect expects props as dependencies, however used object destructuring to extract the filter handler function which is then directly passed as dependency.